### PR TITLE
Fix test setup on Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ install:
         - git clone git://github.com/astropy/ci-helpers.git --depth 1
         - source ci-helpers/travis/setup_conda.sh
         - pip install -r requirements/requirements.txt
-        - pip install codecov coveralls flake8 pytest-cov pytest-astropy
+        - pip install codecov flake8 pytest-cov pytest-astropy
 
 before_script:
     # stop the build if there are Python syntax errors or undefined names
@@ -18,14 +18,10 @@ before_script:
     # exit-zero treats all errors as warnings.  The GitHub editor is 127 chars wide
     - time flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics --exclude=astropy_helpers
 
-# Use next line for testing after HDF5 files are added to MANIFEST.in
-#script: python setup.py test --coverage
-
-script: coverage run -m pytest nei
+script: python setup.py test --coverage
 
 after_success:
     - codecov
-    - coveralls
 
 # We set the language to c because python isn't supported on the MacOS X nodes
 # on Travis. However, the language ends up being irrelevant anyway, since we

--- a/nei/classes/eigenvaluetable.py
+++ b/nei/classes/eigenvaluetable.py
@@ -34,7 +34,7 @@ class EigenData2:
     To get the table for element 'Helium' at Te=5.0e5K:
 
     >>> table = EigenData2(element=2)
-    >>> table.temperature=5.0e5k
+    >>> table.temperature=5.0e5
 
     Output eigenvals:
     >>> table.eigenvalues()


### PR DESCRIPTION
We ran into some problems with testing recently, and the purpose of this pull request is to fix the test setup that we're using for Travis CI.  These are the problems that I think we need to fix:

 - [ ] Fix test failure in `eigenvaluetable.py`
 - [ ] Fix test failure in `nei.py`
 - [ ] Put HDF5 files in `MANIFEST.in` (closes #29)
 - [ ] Get `python setup.py test` to run (instead of using `pytest`, since this makes sure that the package is built which will be important if we put in any Cython)
 - [ ] Switch to codecov instead of coveralls (closes #32)