### PR TITLE
Add adaptive time step capability

### DIFF
--- a/nei/classes/nei.py
+++ b/nei/classes/nei.py
@@ -1156,8 +1156,40 @@ class NEI:
         self._dt = new_dt.to(u.s)
 
     def set_timestep(self, dt: u.Quantity = None):
+        """
+        Set the time step for the next non-equilibrium ionization time
+        advance.
 
-        if dt is not None:  # Allow the time step to set manually.
+        Parameters
+        ----------
+        dt: ~astropy.units.Quantity, optional
+            The time step to be used for the next time advance.
+
+        Notes
+        -----
+        If `dt` is not `None`, then the time step will be set to `dt`.
+
+        If `dt` is not set and the `adapt_dt` attribute of an
+        `~nei.classes.NEI` instance is `True`, then this method will
+        calculate the time step corresponding to how long it will be
+        until the temperature rises or drops into the next temperature
+        bin.  If this time step is between `dtmin` and `dtmax`, then
+
+        If `dt` is not set and the `adapt_dt` attribute is `False`, then
+        this method will set the time step as what was inputted to the
+        `~nei.classes.NEI` class upon instantiation in the `dt` argument
+        or through the `~nei.classes.NEI` class's `dt_input` attribute.
+
+        Raises
+        ------
+        ~nei.classes.NEIError
+            If the time step cannot be set, for example if the `dt`
+            argument is invalid or the time step cannot be adapted.
+
+        """
+
+        if dt is not None:
+            # Allow the time step to set as an argument to this method.
             try:
                 dt = dt.to(u.s)
             except Exception as exc:

--- a/nei/classes/nei.py
+++ b/nei/classes/nei.py
@@ -1284,7 +1284,6 @@ class NEI:
         """
         raise NotImplementedError
 
-
     def visual(self, element):
         """
         Returns an atomic object used for plotting protocols
@@ -1292,7 +1291,7 @@ class NEI:
         Parameter
         ------
         element: str,
-                 The elemental symbol of the particle in question (i.e. 'H')
+            The elemental symbol of the particle in question (i.e. 'H')
 
         Returns
         ------
@@ -1338,7 +1337,6 @@ class NEI:
         """
         index = (np.abs(self.results.time.value - time)).argmin()
 
-
         return index
 
 class Visualize(NEI):
@@ -1355,7 +1353,7 @@ class Visualize(NEI):
         """
         return super(Visualize, self).index_to_time(index)
 
-    def ionicfrac_evol_plot(self,time_sequence, ion='all'):
+    def ionicfrac_evol_plot(self, time_sequence, ion='all'):
         """
         Creates a plot of the ionic fraction time evolution of element inputs
 
@@ -1437,7 +1435,6 @@ class Visualize(NEI):
         fig, ax = plt.subplots()
         if isinstance(time_index, (list, np.ndarray)):
 
-
             alpha = 1.0
             colors = ['blue', 'red']
 
@@ -1471,7 +1468,6 @@ class Visualize(NEI):
             ax.set_ylabel('Ionic Fraction')
             #plt.show()
 
-
     def rh_density_plot(self, gamma, mach, ion='None'):
         """
         Creates a plot of the Rankine-Huguniot jump relation for the
@@ -1486,7 +1482,6 @@ class Visualize(NEI):
         ion: int,
              The ionic integer charge of the element in question
         """
-
 
         #Instantiate the MHD class
         mhd = shocks.MHD()

--- a/nei/classes/tests/test_nei_class.py
+++ b/nei/classes/tests/test_nei_class.py
@@ -127,9 +127,9 @@ tests = {
     'adapt dt': {
         'inputs': ['H', 'He'],
         'abundances': {'H': 1, 'He': 0.1},
-        'T_e': lambda t: u.K * (1e6 + 1e4*np.sin(t.value)),
+        'T_e': lambda t: u.K * (1e6 + 1.3e4*np.sin(t.value)),
         'n': 1e10 * u.cm ** -3,
-        'max_steps': 200,
+        'max_steps': 300,
         'time_start': 0 * u.s,
         'time_max': 2*np.pi * u.s,
         'adapt_dt': True,
@@ -246,6 +246,9 @@ class TestNEI:
         got_to_max_steps = len(time) == instance.max_steps + 1
         got_to_time_max = np.isclose(time[-1].value, instance.time_max.value)
 
+        if time.isscalar or len(time) == 1:
+            raise Exception(f"The only element in results.time is {time}")
+
         if not got_to_max_steps and not got_to_time_max:
             print(f"time = {time}")
             print(f"max_steps = {max_steps}")
@@ -278,3 +281,15 @@ class TestNEI:
         assert initial.abundances == results.abundances
         for elem in initial.elements:
             assert np.allclose(results.ionic_fractions[elem][0, :], initial.ionic_fractions[elem])
+
+    @pytest.mark.parametrize('test_name', test_names)
+    def test_final_results(self, test_name):
+        #initial = self.instances[test_name].initial
+        final = self.instances[test_name].final
+        results = self.instances[test_name].results
+        assert final.elements == results.elements
+        assert final.abundances == results.abundances
+        for elem in final.elements:
+            assert np.allclose(
+                results.ionic_fractions[elem][-1, :], final.ionic_fractions[elem]
+            )

--- a/nei/classes/tests/test_nei_class.py
+++ b/nei/classes/tests/test_nei_class.py
@@ -127,11 +127,11 @@ tests = {
     'adapt dt': {
         'inputs': ['H', 'He'],
         'abundances': {'H': 1, 'He': 0.1},
-        'T_e': lambda t: u.K * (1e6 + 1e5*np.cos(t.value)),
-        'n': 1e9 * u.cm ** -3,
-        'max_steps': 1000,
+        'T_e': lambda t: u.K * (1e6 + 1e4*np.sin(t.value)),
+        'n': 1e10 * u.cm ** -3,
+        'max_steps': 200,
         'time_start': 0 * u.s,
-        'time_max': np.pi * u.s,
+        'time_max': 2*np.pi * u.s,
         'adapt_dt': True,
     },
 }

--- a/nei/classes/tests/test_nei_class.py
+++ b/nei/classes/tests/test_nei_class.py
@@ -122,7 +122,18 @@ tests = {
         'adapt_dt': False,
         'verbose': True,
         'max_steps': 2
-    }
+    },
+
+    'adapt dt': {
+        'inputs': ['H', 'He'],
+        'abundances': {'H': 1, 'He': 0.1},
+        'T_e': lambda t: u.K * (1e6 + 1e5*np.cos(t.value)),
+        'n': 1e9 * u.cm ** -3,
+        'max_steps': 1000,
+        'time_start': 0 * u.s,
+        'time_max': np.pi * u.s,
+        'adapt_dt': True,
+    },
 }
 
 test_names = list(tests.keys())


### PR DESCRIPTION
This PR implements an adaptive time step capability that chooses a time step based on when the plasma enters the next temperature bin (and thus different ionization/recombination rates).  We might also want to implement something that limits the time step based on the density changes as well.  

This is not yet ready to merge since I want to add some docstrings and possibly some more tests.
