### PR TITLE
Improve density/temperature interpolation behavior

### DIFF
--- a/nei/classes/nei.py
+++ b/nei/classes/nei.py
@@ -793,7 +793,7 @@ class NEI:
             raise TypeError("Invalid choice for verbose.")
 
     @u.quantity_input
-    def in_time_interval(self, time: u.s, buffer: u.s = 1e-9 * u.s) -> bool:
+    def in_time_interval(self, time: u.s, buffer: u.s = 1e-9 * u.s):
         """
         Return `True` if the `time` is between `time_start - buffer` and
         `time_max + buffer` , and `False` otherwise.


### PR DESCRIPTION
When the number density or temperature input was given as an array of values, then an exception was being raised for cases where the time was outside of the time interval.  This could lead to problems if, for example, there was roundoff error.  

This pull request changes the behavior so that the electron density and temperature can be calculated outside of the time interval, but with a warning being issued.  I also modifed `NEI.in_time_interval` to allow for a time buffer in case of roundoff error.